### PR TITLE
Update SQLAlchemy demo to use modern 1.4 / 2.0 idioms and add asyncio benchmark

### DIFF
--- a/_shared.py
+++ b/_shared.py
@@ -26,6 +26,7 @@ from _django import queries as django_queries
 from _django import queries_restfw as django_queries_restfw
 from _mongodb import queries as mongodb_queries
 from _sqlalchemy import queries as sqlalchemy_queries
+from _sqlalchemy import queries_asyncio as sqlalchemy_queries_asyncio
 from _postgres import queries as postgres_queries
 from _postgres import queries_psycopg as postgres_psycopg_queries
 
@@ -70,6 +71,9 @@ IMPLEMENTATIONS = {
 
     'sqlalchemy':
         impl('python', 'SQLAlchemy', sqlalchemy_queries),
+
+    'sqlalchemy_asyncio':
+        impl('python', 'SQLAlchemy (asyncio)', sqlalchemy_queries_asyncio),
 
     'postgres_asyncpg':
         impl('python', 'PostgreSQL (Python, asyncpg)', postgres_queries),

--- a/_sqlalchemy/loaddata.py
+++ b/_sqlalchemy/loaddata.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     engine = sa.create_engine(
-        "postgresql://sqlalch_bench:edgedbbenchmark@localhost:15432/sqlalch_bench"
+        "postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@localhost:15432/sqlalch_bench?async_fallback=True"
     )
 
     load_data(args.filename, engine)

--- a/_sqlalchemy/migrations/alembic.ini
+++ b/_sqlalchemy/migrations/alembic.ini
@@ -10,7 +10,7 @@
 
 script_location = .
 
-sqlalchemy.url = postgresql://sqlalch_bench:edgedbbenchmark@localhost:15432/sqlalch_bench
+sqlalchemy.url = postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@localhost:15432/sqlalch_bench?async_fallback=true
 
 
 # Logging configuration

--- a/_sqlalchemy/migrations/versions/549d8cfe5668_.py
+++ b/_sqlalchemy/migrations/versions/549d8cfe5668_.py
@@ -67,7 +67,7 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('body', sa.String(), nullable=False),
     sa.Column('rating', sa.Integer(), nullable=False),
-    sa.Column('creation_time', sa.DateTime(), nullable=False),
+    sa.Column('creation_time', sa.DateTime(timezone=True), nullable=False),
     sa.Column('author_id', sa.Integer(), nullable=False),
     sa.Column('movie_id', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['author_id'], ['user.id'], ),

--- a/_sqlalchemy/models.py
+++ b/_sqlalchemy/models.py
@@ -11,7 +11,7 @@ import sqlalchemy.orm as orm
 
 from sqlalchemy import select, func
 
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 
 Base = declarative_base()

--- a/_sqlalchemy/models.py
+++ b/_sqlalchemy/models.py
@@ -107,7 +107,7 @@ class Review(Base):
     id = sa.Column(sa.Integer(), primary_key=True)
     body = sa.Column(sa.String(), nullable=False)
     rating = sa.Column(sa.Integer(), nullable=False)
-    creation_time = sa.Column(sa.DateTime(), nullable=False)
+    creation_time = sa.Column(sa.DateTime(timezone=True), nullable=False)
 
     author_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'),
                           nullable=False, index=True)

--- a/_sqlalchemy/models.py
+++ b/_sqlalchemy/models.py
@@ -18,55 +18,60 @@ Base = declarative_base()
 
 
 class User(Base):
-    __tablename__ = 'user'
+    __tablename__ = "user"
 
     id = sa.Column(sa.Integer(), primary_key=True)
     name = sa.Column(sa.String(), nullable=False)
     image = sa.Column(sa.String(), nullable=False)
 
     reviews = orm.relationship(
-        'Review', back_populates='author',
-        cascade='all, delete, delete-orphan')
+        "Review", back_populates="author",
+        cascade="all, delete, delete-orphan")
     latest_reviews = orm.relationship(
-        'Review', order_by=lambda: Review.creation_time.desc(),
-        lazy='dynamic', bake_queries=True, viewonly=True)
+        "Review", order_by=lambda: Review.creation_time.desc(), viewonly=True)
 
 
 class Directors(Base):
-    __tablename__ = 'directors'
+    __tablename__ = "directors"
 
     id = sa.Column(sa.Integer(), primary_key=True)
     list_order = sa.Column(sa.Integer(), nullable=True)
 
-    person_id = sa.Column(sa.Integer, sa.ForeignKey('person.id'),
+    person_id = sa.Column(sa.Integer, sa.ForeignKey("person.id"),
                           nullable=False, index=True)
-    person_rel = orm.relationship('Person', back_populates='directed_rel')
-    movie_id = sa.Column(sa.Integer, sa.ForeignKey('movie.id'),
+    person_rel = orm.relationship(
+        "Person", back_populates="directed_rel", innerjoin=True
+    )
+    movie_id = sa.Column(sa.Integer, sa.ForeignKey("movie.id"),
                          nullable=False, index=True)
-    movie_rel = orm.relationship('Movie', back_populates='directors_rel')
+    movie_rel = orm.relationship(
+        "Movie", back_populates="directors_rel", innerjoin=True
+    )
 
 
 class Cast(Base):
-    __tablename__ = 'cast'
+    __tablename__ = "cast"
 
     id = sa.Column(sa.Integer(), primary_key=True)
     list_order = sa.Column(sa.Integer(), nullable=True)
 
-    person_id = sa.Column(sa.Integer, sa.ForeignKey('person.id'),
+    person_id = sa.Column(sa.Integer, sa.ForeignKey("person.id"),
                           nullable=False, index=True)
-    person_rel = orm.relationship('Person', back_populates='acted_in_rel')
+    person_rel = orm.relationship(
+        "Person", back_populates="acted_in_rel", innerjoin=True
+    )
 
-    movie_id = sa.Column(sa.Integer, sa.ForeignKey('movie.id'),
+    movie_id = sa.Column(sa.Integer, sa.ForeignKey("movie.id"),
                          nullable=False, index=True)
-    movie_rel = orm.relationship('Movie', back_populates='cast_rel')
+    movie_rel = orm.relationship("Movie", back_populates="cast_rel", innerjoin=True)
 
 
 class Person(Base):
-    __tablename__ = 'person'
+    __tablename__ = "person"
 
     id = sa.Column(sa.Integer(), primary_key=True)
     first_name = sa.Column(sa.String(), nullable=False)
-    middle_name = sa.Column(sa.String(), nullable=False, server_default='')
+    middle_name = sa.Column(sa.String(), nullable=False, server_default="")
     last_name = sa.Column(sa.String(), nullable=False)
     image = sa.Column(sa.String(), nullable=False)
     bio = sa.Column(sa.String(), nullable=False)
@@ -74,52 +79,56 @@ class Person(Base):
     # These are direct relationships between people and movies.
     # They are useful when the 'list_order' is irrelevant
     directed = orm.relationship(
-        'Movie',
+        "Movie",
         secondary=Directors.__table__,
-        backref='directors',
+        backref="directors",
         viewonly=True,
     )
     acted_in = orm.relationship(
-        'Movie',
+        "Movie",
         secondary=Cast.__table__,
-        backref='cast',
+        backref="cast",
         viewonly=True,
     )
 
     directed_rel = orm.relationship(
-        Directors, back_populates='person_rel',
-        cascade='all, delete, delete-orphan')
+        Directors, back_populates="person_rel",
+        cascade="all, delete, delete-orphan"
+    )
     acted_in_rel = orm.relationship(
-        Cast, back_populates='person_rel',
-        cascade='all, delete, delete-orphan')
+        Cast, back_populates="person_rel",
+        cascade="all, delete, delete-orphan"
+    )
 
     @property
     def full_name(self):
         if self.middle_name:
-            return f'{self.first_name} {self.middle_name} {self.last_name}'
+            return f"{self.first_name} {self.middle_name} {self.last_name}"
         else:
-            return f'{self.first_name} {self.last_name}'
+            return f"{self.first_name} {self.last_name}"
 
 
 class Review(Base):
-    __tablename__ = 'review'
+    __tablename__ = "review"
 
     id = sa.Column(sa.Integer(), primary_key=True)
     body = sa.Column(sa.String(), nullable=False)
     rating = sa.Column(sa.Integer(), nullable=False)
     creation_time = sa.Column(sa.DateTime(timezone=True), nullable=False)
 
-    author_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'),
-                          nullable=False, index=True)
-    author = orm.relationship(User, back_populates='reviews')
+    author_id = sa.Column(
+        sa.Integer, sa.ForeignKey("user.id"), nullable=False, index=True
+    )
+    author = orm.relationship(User, back_populates="reviews", innerjoin=True)
 
-    movie_id = sa.Column(sa.Integer, sa.ForeignKey('movie.id'),
-                         nullable=False, index=True)
-    movie = orm.relationship('Movie', back_populates='reviews')
+    movie_id = sa.Column(
+        sa.Integer, sa.ForeignKey("movie.id"), nullable=False, index=True
+    )
+    movie = orm.relationship("Movie", back_populates="reviews", innerjoin=True)
 
 
 class Movie(Base):
-    __tablename__ = 'movie'
+    __tablename__ = "movie"
 
     id = sa.Column(sa.Integer(), primary_key=True)
     image = sa.Column(sa.String(), nullable=False)
@@ -128,20 +137,19 @@ class Movie(Base):
     description = sa.Column(sa.String(), nullable=False)
 
     reviews = orm.relationship(
-        Review, back_populates='movie',
-        cascade='all, delete, delete-orphan')
+        Review, back_populates="movie", cascade="all, delete, delete-orphan"
+    )
 
     directors_rel = orm.relationship(
-        Directors, back_populates='movie_rel',
-        cascade='all, delete, delete-orphan')
+        Directors, back_populates="movie_rel", cascade="all, delete, delete-orphan"
+    )
     cast_rel = orm.relationship(
-        Cast, back_populates='movie_rel',
-        cascade='all, delete, delete-orphan')
+        Cast, back_populates="movie_rel", cascade="all, delete, delete-orphan"
+    )
 
     avg_rating = orm.column_property(
-        select(
-            [func.avg(Review.rating)]
-        ).where(
-            Review.movie_id == id
-        ).correlate_except(Review).scalar_subquery()
+        select(func.avg(Review.rating))
+        .where(Review.movie_id == id)
+        .correlate_except(Review)
+        .scalar_subquery()
     )

--- a/_sqlalchemy/queries.py
+++ b/_sqlalchemy/queries.py
@@ -219,15 +219,15 @@ def get_person(sess, id):
 def update_movie(sess, id):
     stmt = (
         sa.update(m.Movie)
-        .filter_by(id=sa.bindparam("m_id"))
-        .values(title=m.Movie.title + sa.bindparam("suffix"))
+        .filter_by(id=id)
+        .values(title=m.Movie.title + f"---{str(id)[:8]}")
         .returning(
             m.Movie.id,
             m.Movie.title,
         )
     )
 
-    result = sess.execute(stmt, dict(m_id=id, suffix=f"---{str(id)[:8]}")).first()
+    result = sess.execute(stmt).first()
     # Without this commit, the changes end up being committed outside
     # of where they are timed.
     sess.commit()

--- a/_sqlalchemy/queries.py
+++ b/_sqlalchemy/queries.py
@@ -24,8 +24,8 @@ def connect(ctx):
 
     if session_factory is None:
         engine = sa.create_engine(
-            f"postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@"
-            f"{ctx.db_host}:{ctx.pg_port}/sqlalch_bench?async_fallback=true"
+            f"postgresql://sqlalch_bench:edgedbbenchmark@"
+            f"{ctx.db_host}:{ctx.pg_port}/sqlalch_bench"
         )
         session_factory = orm.sessionmaker(bind=engine, expire_on_commit=False)
 

--- a/_sqlalchemy/queries.py
+++ b/_sqlalchemy/queries.py
@@ -10,14 +10,12 @@ import json
 import random
 import sqlalchemy as sa
 import sqlalchemy.orm as orm
-from sqlalchemy.ext import baked
 import _sqlalchemy.models as m
 
 
 engine = None
 session_factory = None
-bakery = baked.bakery()
-INSERT_PREFIX = 'insert_test__'
+INSERT_PREFIX = "insert_test__"
 
 
 def connect(ctx):
@@ -26,8 +24,9 @@ def connect(ctx):
 
     if session_factory is None:
         engine = sa.create_engine(
-            f'postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@'
-            f'{ctx.db_host}:{ctx.pg_port}/sqlalch_bench?async_fallback=true')
+            f"postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@"
+            f"{ctx.db_host}:{ctx.pg_port}/sqlalch_bench?async_fallback=true"
+        )
         session_factory = orm.sessionmaker(bind=engine, expire_on_commit=False)
 
     return session_factory()
@@ -38,22 +37,16 @@ def close(ctx, sess):
 
 
 def load_ids(ctx, sess):
-    users = (
-        sess.query(m.User)
-        .order_by(sa.func.random())
-        .limit(ctx.number_of_ids)
+    users = sess.scalars(
+        sa.select(m.User).order_by(sa.func.random()).limit(ctx.number_of_ids)
     ).all()
 
-    movies = (
-        sess.query(m.Movie)
-        .order_by(sa.func.random())
-        .limit(ctx.number_of_ids)
+    movies = sess.scalars(
+        sa.select(m.Movie).order_by(sa.func.random()).limit(ctx.number_of_ids)
     ).all()
 
-    people = (
-        sess.query(m.Person)
-        .order_by(sa.func.random())
-        .limit(ctx.number_of_ids)
+    people = sess.scalars(
+        sa.select(m.Person).order_by(sa.func.random()).limit(ctx.number_of_ids)
     ).all()
 
     return dict(
@@ -65,40 +58,50 @@ def load_ids(ctx, sess):
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
         insert_user=[INSERT_PREFIX] * ctx.concurrency,
-        insert_movie=[{
-            'prefix': INSERT_PREFIX,
-            'people': [p.id for p in people[:4]],
-        }] * ctx.concurrency,
+        insert_movie=[
+            {
+                "prefix": INSERT_PREFIX,
+                "people": [p.id for p in people[:4]],
+            }
+        ]
+        * ctx.concurrency,
         insert_movie_plus=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
 def get_user(sess, id):
-    user_query = bakery(lambda sess: sess.query(m.User))
-    user_query += lambda q: q.filter_by(id=sa.bindparam('id'))
-    user = user_query(sess).params(id=id).first()
+    user_query = sa.select(m.User).filter_by(id=id)
+    user = sess.scalars(user_query).first()
 
-    latest_reviews = user.latest_reviews.options(
-        orm.joinedload(m.Review.movie)).limit(10).all()
+    stmt = (
+        sa.select(m.Review)
+        .where(orm.with_parent(user, m.User.latest_reviews))
+        .options(orm.joinedload(m.Review.movie))
+        .limit(10)
+    )
+    latest_reviews = sess.scalars(stmt).all()
 
-    result = json.dumps({
-        'id': user.id,
-        'name': user.name,
-        'image': user.image,
-        'latest_reviews': [
-            {
-                'id': r.id,
-                'body': r.body,
-                'rating': r.rating,
-                'movie': {
-                    'id': r.movie.id,
-                    'image': r.movie.image,
-                    'title': r.movie.title,
-                    'avg_rating': float(r.movie.avg_rating),
+    result = json.dumps(
+        {
+            "id": user.id,
+            "name": user.name,
+            "image": user.image,
+            "latest_reviews": [
+                {
+                    "id": r.id,
+                    "body": r.body,
+                    "rating": r.rating,
+                    "movie": {
+                        "id": r.movie.id,
+                        "image": r.movie.image,
+                        "title": r.movie.title,
+                        "avg_rating": float(r.movie.avg_rating),
+                    },
                 }
-            } for r in latest_reviews
-        ]
-    })
+                for r in latest_reviews
+            ],
+        }
+    )
     return result
 
 
@@ -113,105 +116,99 @@ def get_movie(sess, id):
         else:
             return (rel.list_order, rel.person_rel.last_name)
 
-    baked_query = bakery(lambda sess: (
-        sess.query(m.Movie)
-            .options(
-                orm.subqueryload(m.Movie.directors_rel)
-                .joinedload(m.Directors.person_rel, innerjoin=True),
-
-                orm.subqueryload(m.Movie.cast_rel)
-                .joinedload(m.Cast.person_rel, innerjoin=True),
-
-                orm.subqueryload(m.Movie.reviews)
-                .joinedload(m.Review.author, innerjoin=True),
-            )
+    stmt = (
+        sa.select(m.Movie)
+        .options(
+            orm.selectinload(m.Movie.directors_rel).joinedload(m.Directors.person_rel),
+            orm.selectinload(m.Movie.cast_rel).joinedload(m.Cast.person_rel),
+            orm.selectinload(m.Movie.reviews).joinedload(m.Review.author),
         )
+        .filter_by(id=id)
     )
 
-    baked_query += lambda q: q.filter_by(id=sa.bindparam('id'))
+    movie = sess.scalars(stmt).first()
 
-    movie = baked_query(sess).params(id=id).first()
+    directors = [rel.person_rel for rel in sorted(movie.directors_rel, key=sort_key)]
 
-    directors = [rel.person_rel for rel in
-                 sorted(movie.directors_rel, key=sort_key)]
-
-    cast = [rel.person_rel for rel in
-            sorted(movie.cast_rel, key=sort_key)]
+    cast = [rel.person_rel for rel in sorted(movie.cast_rel, key=sort_key)]
 
     result = {
-        'id': movie.id,
-        'image': movie.image,
-        'title': movie.title,
-        'year': movie.year,
-        'description': movie.description,
-        'avg_rating': float(movie.avg_rating),
-        'directors': [
+        "id": movie.id,
+        "image": movie.image,
+        "title": movie.title,
+        "year": movie.year,
+        "description": movie.description,
+        "avg_rating": float(movie.avg_rating),
+        "directors": [
             {
-                'id': d.id,
-                'full_name': d.full_name,
-                'image': d.image,
-            } for d in directors
+                "id": d.id,
+                "full_name": d.full_name,
+                "image": d.image,
+            }
+            for d in directors
         ],
-        'cast': [
+        "cast": [
             {
-                'id': c.id,
-                'full_name': c.full_name,
-                'image': c.image,
-            } for c in cast
+                "id": c.id,
+                "full_name": c.full_name,
+                "image": c.image,
+            }
+            for c in cast
         ],
-        'reviews': [
+        "reviews": [
             {
-                'id': r.id,
-                'body': r.body,
-                'rating': float(r.rating),
-                'author': {
-                    'id': r.author.id,
-                    'name': r.author.name,
-                    'image': r.author.image,
-                }
-            } for r in sorted(movie.reviews,
-                              key=lambda x: x.creation_time,
-                              reverse=True)
-        ]
+                "id": r.id,
+                "body": r.body,
+                "rating": float(r.rating),
+                "author": {
+                    "id": r.author.id,
+                    "name": r.author.name,
+                    "image": r.author.image,
+                },
+            }
+            for r in sorted(movie.reviews, key=lambda x: x.creation_time, reverse=True)
+        ],
     }
 
     return json.dumps(result)
 
 
 def get_person(sess, id):
-    baked_query = bakery(lambda sess: sess.query(m.Person).options(
-        orm.joinedload(m.Person.acted_in),
-        orm.joinedload(m.Person.directed),
-    ))
+    stmt = (
+        sa.select(m.Person)
+        .options(
+            orm.selectinload(m.Person.acted_in),
+            orm.selectinload(m.Person.directed),
+        )
+        .filter_by(id=id)
+    )
 
-    baked_query += lambda q: q.filter_by(id=sa.bindparam('id'))
-
-    person = baked_query(sess).params(id=id).first()
+    person = sess.scalars(stmt).first()
 
     result = {
-        'id': person.id,
-        'image': person.image,
-        'full_name': person.full_name,
-        'bio': person.bio,
-        'acted_in': [
+        "id": person.id,
+        "image": person.image,
+        "full_name": person.full_name,
+        "bio": person.bio,
+        "acted_in": [
             {
-                'id': m.id,
-                'image': m.image,
-                'title': m.title,
-                'year': m.year,
-                'avg_rating': float(m.avg_rating),
-            } for m in sorted(person.acted_in,
-                              key=lambda x: (x.year, x.title))
+                "id": m.id,
+                "image": m.image,
+                "title": m.title,
+                "year": m.year,
+                "avg_rating": float(m.avg_rating),
+            }
+            for m in sorted(person.acted_in, key=lambda x: (x.year, x.title))
         ],
-        'directed': [
+        "directed": [
             {
-                'id': m.id,
-                'image': m.image,
-                'title': m.title,
-                'year': m.year,
-                'avg_rating': float(m.avg_rating),
-            } for m in sorted(person.directed,
-                              key=lambda x: (x.year, x.title))
+                "id": m.id,
+                "image": m.image,
+                "title": m.title,
+                "year": m.year,
+                "avg_rating": float(m.avg_rating),
+            }
+            for m in sorted(person.directed, key=lambda x: (x.year, x.title))
         ],
     }
 
@@ -219,42 +216,42 @@ def get_person(sess, id):
 
 
 def update_movie(sess, id):
-    stmt = sa.update(
-        m.Movie
-    ).filter_by(
-        id=sa.bindparam('m_id')
-    ).values(
-        title=m.Movie.title + sa.bindparam('suffix')
-    ).returning(
-        m.Movie.id,
-        m.Movie.title,
+    stmt = (
+        sa.update(m.Movie)
+        .filter_by(id=sa.bindparam("m_id"))
+        .values(title=m.Movie.title + sa.bindparam("suffix"))
+        .returning(
+            m.Movie.id,
+            m.Movie.title,
+        )
     )
 
-    result = sess.execute(
-        stmt,
-        dict(m_id=id, suffix=f'---{str(id)[:8]}')
-    ).first()
+    result = sess.execute(stmt, dict(m_id=id, suffix=f"---{str(id)[:8]}")).first()
     # Without this commit, the changes end up being committed outside
     # of where they are timed.
     sess.commit()
 
-    return json.dumps({
-        'id': result[0],
-        'title': result[1],
-    })
+    return json.dumps(
+        {
+            "id": result[0],
+            "title": result[1],
+        }
+    )
 
 
 def insert_user(sess, val):
     num = random.randrange(1_000_000)
-    user = m.User(name=f'{val}{num}', image=f'image_{val}{num}')
+    user = m.User(name=f"{val}{num}", image=f"image_{val}{num}")
     sess.add(user)
     sess.commit()
 
-    return json.dumps({
-        'id': user.id,
-        'name': user.name,
-        'image': user.image,
-    })
+    return json.dumps(
+        {
+            "id": user.id,
+            "name": user.name,
+            "image": user.image,
+        }
+    )
 
 
 def insert_movie(sess, val):
@@ -273,30 +270,31 @@ def insert_movie(sess, val):
     c0 = m.Cast(person_id=val["people"][1], movie_id=movie.id)
     c1 = m.Cast(person_id=val["people"][2], movie_id=movie.id)
     c2 = m.Cast(person_id=val["people"][3], movie_id=movie.id)
-    sess.add(c0)
-    sess.add(c1)
-    sess.add(c2)
+
+    sess.add_all([c0, c1, c2])
+
     sess.commit()
 
     result = {
-        'id': movie.id,
-        'image': movie.image,
-        'title': movie.title,
-        'year': movie.year,
-        'description': movie.description,
-        'directors': [
+        "id": movie.id,
+        "image": movie.image,
+        "title": movie.title,
+        "year": movie.year,
+        "description": movie.description,
+        "directors": [
             {
-                'id': directors.person_rel.id,
-                'full_name': directors.person_rel.full_name,
-                'image': directors.person_rel.image,
+                "id": directors.person_rel.id,
+                "full_name": directors.person_rel.full_name,
+                "image": directors.person_rel.image,
             }
         ],
-        'cast': [
+        "cast": [
             {
-                'id': c.person_rel.id,
-                'full_name': c.person_rel.full_name,
-                'image': c.person_rel.image,
-            } for c in [c0, c1, c2]
+                "id": c.person_rel.id,
+                "full_name": c.person_rel.full_name,
+                "image": c.person_rel.image,
+            }
+            for c in [c0, c1, c2]
         ],
     }
     return json.dumps(result)
@@ -305,114 +303,119 @@ def insert_movie(sess, val):
 def insert_movie_plus(sess, val):
     num = random.randrange(1_000_000)
     director = m.Person(
-        first_name=f'{val}Alice',
-        last_name=f'{val}Director',
-        image=f'{val}image{num}.jpeg',
-        bio='',
+        first_name=f"{val}Alice",
+        last_name=f"{val}Director",
+        image=f"{val}image{num}.jpeg",
+        bio="",
     )
     c0 = m.Person(
-        first_name=f'{val}Billie',
-        last_name=f'{val}Actor',
-        image=f'{val}image{num+1}.jpeg',
-        bio='',
+        first_name=f"{val}Billie",
+        last_name=f"{val}Actor",
+        image=f"{val}image{num+1}.jpeg",
+        bio="",
     )
     c1 = m.Person(
-        first_name=f'{val}Cameron',
-        last_name=f'{val}Actor',
-        image=f'{val}image{num+2}.jpeg',
-        bio='',
+        first_name=f"{val}Cameron",
+        last_name=f"{val}Actor",
+        image=f"{val}image{num+2}.jpeg",
+        bio="",
     )
-    sess.add(director)
-    sess.add(c0)
-    sess.add(c1)
     movie = m.Movie(
-        title=f'{val}{num}',
-        image=f'{val}image{num}.jpeg',
-        description=f'{val}description{num}',
+        title=f"{val}{num}",
+        image=f"{val}image{num}.jpeg",
+        description=f"{val}description{num}",
         year=num,
     )
-    sess.add(movie)
+
+    sess.add_all([
+        director,
+        c0,
+        c1,
+        movie
+    ])
     sess.commit()
 
-    sess.add(m.Directors(person_id=director.id, movie_id=movie.id))
-    sess.add(m.Cast(person_id=c0.id, movie_id=movie.id))
-    sess.add(m.Cast(person_id=c1.id, movie_id=movie.id))
+    sess.add_all([
+        m.Directors(person_id=director.id, movie_id=movie.id),
+        m.Cast(person_id=c0.id, movie_id=movie.id),
+        m.Cast(person_id=c1.id, movie_id=movie.id)
+    ])
+
     sess.commit()
 
     result = {
-        'id': movie.id,
-        'image': movie.image,
-        'title': movie.title,
-        'year': movie.year,
-        'description': movie.description,
-        'directors': [
+        "id": movie.id,
+        "image": movie.image,
+        "title": movie.title,
+        "year": movie.year,
+        "description": movie.description,
+        "directors": [
             {
-                'id': director.id,
-                'full_name': director.full_name,
-                'image': director.image,
+                "id": director.id,
+                "full_name": director.full_name,
+                "image": director.image,
             }
         ],
-        'cast': [
+        "cast": [
             {
-                'id': c.id,
-                'full_name': c.full_name,
-                'image': c.image,
-            } for c in [c0, c1]
+                "id": c.id,
+                "full_name": c.full_name,
+                "image": c.image,
+            }
+            for c in [c0, c1]
         ],
     }
     return json.dumps(result)
 
 
 def setup(ctx, sess, queryname):
-    if queryname == 'update_movie':
-        sess.query(
-            m.Movie
-        ).update(
-            dict(title=sa.func.split_part(m.Movie.title, '---', 1))
+    if queryname == "update_movie":
+        sess.execute(
+            sa.update(m.Movie)
+            .values(title=sa.func.split_part(m.Movie.title, "---", 1))
+            .execution_options(synchronize_session=False)
         )
         sess.commit()
-    elif queryname == 'insert_user':
-        sess.query(
-            m.User
-        ).filter(
-            m.User.name.like(f'{INSERT_PREFIX}%')
-        ).delete(synchronize_session=False)
+    elif queryname == "insert_user":
+        sess.execute(
+            sa.delete(m.User)
+            .where(m.User.name.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
         sess.commit()
-    elif queryname in {'insert_movie', 'insert_movie_plus'}:
-        # XXX: I just gave up on trying to figure out how to bulk delete
-        # all this in SQLAlchemy proper. Trying to filter the
-        # relationships based on the Movie they target didn't seem to
-        # work. So I'll use a raw query.
-        sess.execute('''
-            DELETE FROM
-                "directors" as D
-            USING
-                "movie" as M
-            WHERE
-                D.movie_id = M.id AND M.image LIKE 'insert_test__%';
+    elif queryname in {"insert_movie", "insert_movie_plus"}:
 
-            DELETE FROM
-                "cast" as C
-            USING
-                "movie" as M
-            WHERE
-                C.movie_id = M.id AND M.image LIKE 'insert_test__%';
-
-            DELETE FROM
-                "movie" as M
-            WHERE
-                M.image LIKE 'insert_test__%';
-
-            DELETE FROM
-                "person" as P
-            WHERE
-                P.image LIKE 'insert_test__%';
-        ''')
+        sess.execute(
+            sa.delete(m.Directors)
+            .where(m.Directors.movie_rel)
+            .where(m.Movie.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        sess.execute(
+            sa.delete(m.Cast)
+            .where(m.Cast.movie_rel)
+            .where(m.Movie.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        sess.execute(
+            sa.delete(m.Movie)
+            .where(m.Movie.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        sess.execute(
+            sa.delete(m.Person)
+            .where(m.Person.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
         sess.commit()
 
 
 def cleanup(ctx, sess, queryname):
-    if queryname in {'update_movie', 'insert_user', 'insert_movie',
-                     'insert_movie_plus'}:
+    if queryname in {
+        "update_movie",
+        "insert_user",
+        "insert_movie",
+        "insert_movie_plus",
+    }:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, sess, queryname)

--- a/_sqlalchemy/queries.py
+++ b/_sqlalchemy/queries.py
@@ -28,7 +28,7 @@ def connect(ctx):
         engine = sa.create_engine(
             f'postgresql://sqlalch_bench:edgedbbenchmark@'
             f'{ctx.db_host}:{ctx.pg_port}/sqlalch_bench')
-        session_factory = orm.sessionmaker(bind=engine)
+        session_factory = orm.sessionmaker(bind=engine, expire_on_commit=False)
 
     return session_factory()
 

--- a/_sqlalchemy/queries.py
+++ b/_sqlalchemy/queries.py
@@ -26,8 +26,8 @@ def connect(ctx):
 
     if session_factory is None:
         engine = sa.create_engine(
-            f'postgresql://sqlalch_bench:edgedbbenchmark@'
-            f'{ctx.db_host}:{ctx.pg_port}/sqlalch_bench')
+            f'postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@'
+            f'{ctx.db_host}:{ctx.pg_port}/sqlalch_bench?async_fallback=true')
         session_factory = orm.sessionmaker(bind=engine, expire_on_commit=False)
 
     return session_factory()

--- a/_sqlalchemy/queries_asyncio.py
+++ b/_sqlalchemy/queries_asyncio.py
@@ -229,8 +229,8 @@ async def get_person(sess, id):
 async def update_movie(sess, id):
     stmt = (
         sa.update(m.Movie)
-        .filter_by(id=sa.bindparam("m_id"))
-        .values(title=m.Movie.title + sa.bindparam("suffix"))
+        .filter_by(id=id)
+        .values(title=m.Movie.title + f"---{str(id)[:8]}")
         .returning(
             m.Movie.id,
             m.Movie.title,
@@ -238,8 +238,9 @@ async def update_movie(sess, id):
     )
 
     result = (
-        await sess.execute(stmt, dict(m_id=id, suffix=f"---{str(id)[:8]}"))
+        await sess.execute(stmt)
     ).first()
+
     # Without this commit, the changes end up being committed outside
     # of where they are timed.
     await sess.commit()

--- a/_sqlalchemy/queries_asyncio.py
+++ b/_sqlalchemy/queries_asyncio.py
@@ -1,0 +1,442 @@
+#
+# Copyright (c) 2019 MagicStack Inc.
+# All rights reserved.
+#
+# See LICENSE for details.
+##
+
+
+import json
+import random
+import sqlalchemy as sa
+import sqlalchemy.ext.asyncio as sa_asyncio
+import sqlalchemy.orm as orm
+import _sqlalchemy.models as m
+
+
+engine = None
+session_factory = None
+ASYNC = True
+INSERT_PREFIX = "insert_test__"
+
+
+async def connect(ctx):
+    global engine
+    global session_factory
+
+    if session_factory is None:
+        engine = sa_asyncio.create_async_engine(
+            f"postgresql+asyncpg://sqlalch_bench:edgedbbenchmark@"
+            f"{ctx.db_host}:{ctx.pg_port}/sqlalch_bench"
+        )
+        session_factory = orm.sessionmaker(
+            bind=engine, expire_on_commit=False, class_=sa_asyncio.AsyncSession
+        )
+
+    return session_factory()
+
+
+async def close(ctx, sess):
+    await sess.close()
+    await sess.bind.dispose()
+
+
+async def load_ids(ctx, sess):
+    users = (
+        await sess.scalars(
+            sa.select(m.User).order_by(sa.func.random()).limit(ctx.number_of_ids)
+        )
+    ).all()
+
+    movies = (
+        await sess.scalars(
+            sa.select(m.Movie).order_by(sa.func.random()).limit(ctx.number_of_ids)
+        )
+    ).all()
+
+    people = (
+        await sess.scalars(
+            sa.select(m.Person).order_by(sa.func.random()).limit(ctx.number_of_ids)
+        )
+    ).all()
+
+    return dict(
+        get_user=[u.id for u in users],
+        get_movie=[m.id for m in movies],
+        get_person=[p.id for p in people],
+        # re-use user IDs for update tests
+        update_movie=[m.id for m in movies],
+        # generate as many insert stubs as "concurrency" to
+        # accommodate concurrent inserts
+        insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_movie=[
+            {
+                "prefix": INSERT_PREFIX,
+                "people": [p.id for p in people[:4]],
+            }
+        ]
+        * ctx.concurrency,
+        insert_movie_plus=[INSERT_PREFIX] * ctx.concurrency,
+    )
+
+
+async def get_user(sess, id):
+    user_query = sa.select(m.User).filter_by(id=id)
+    user = (await sess.scalars(user_query)).first()
+
+    stmt = (
+        sa.select(m.Review)
+        .where(orm.with_parent(user, m.User.latest_reviews))
+        .options(orm.joinedload(m.Review.movie))
+        .limit(10)
+    )
+    latest_reviews = (await sess.scalars(stmt)).all()
+
+    result = json.dumps(
+        {
+            "id": user.id,
+            "name": user.name,
+            "image": user.image,
+            "latest_reviews": [
+                {
+                    "id": r.id,
+                    "body": r.body,
+                    "rating": r.rating,
+                    "movie": {
+                        "id": r.movie.id,
+                        "image": r.movie.image,
+                        "title": r.movie.title,
+                        "avg_rating": float(r.movie.avg_rating),
+                    },
+                }
+                for r in latest_reviews
+            ],
+        }
+    )
+    return result
+
+
+async def get_movie(sess, id):
+    # to implement NULLS LAST use a numeric value larger than any
+    # list order we can get from the DB
+    NULLS_LAST = 2 ^ 64
+
+    def sort_key(rel):
+        if rel.list_order is None:
+            return (NULLS_LAST, rel.person_rel.last_name)
+        else:
+            return (rel.list_order, rel.person_rel.last_name)
+
+    stmt = (
+        sa.select(m.Movie)
+        .options(
+            orm.selectinload(m.Movie.directors_rel).joinedload(m.Directors.person_rel),
+            orm.selectinload(m.Movie.cast_rel).joinedload(m.Cast.person_rel),
+            orm.selectinload(m.Movie.reviews).joinedload(m.Review.author),
+        )
+        .filter_by(id=id)
+    )
+
+    movie = (await sess.scalars(stmt)).first()
+
+    directors = [rel.person_rel for rel in sorted(movie.directors_rel, key=sort_key)]
+
+    cast = [rel.person_rel for rel in sorted(movie.cast_rel, key=sort_key)]
+
+    result = {
+        "id": movie.id,
+        "image": movie.image,
+        "title": movie.title,
+        "year": movie.year,
+        "description": movie.description,
+        "avg_rating": float(movie.avg_rating),
+        "directors": [
+            {
+                "id": d.id,
+                "full_name": d.full_name,
+                "image": d.image,
+            }
+            for d in directors
+        ],
+        "cast": [
+            {
+                "id": c.id,
+                "full_name": c.full_name,
+                "image": c.image,
+            }
+            for c in cast
+        ],
+        "reviews": [
+            {
+                "id": r.id,
+                "body": r.body,
+                "rating": float(r.rating),
+                "author": {
+                    "id": r.author.id,
+                    "name": r.author.name,
+                    "image": r.author.image,
+                },
+            }
+            for r in sorted(movie.reviews, key=lambda x: x.creation_time, reverse=True)
+        ],
+    }
+
+    return json.dumps(result)
+
+
+async def get_person(sess, id):
+    stmt = (
+        sa.select(m.Person)
+        .options(
+            orm.selectinload(m.Person.acted_in),
+            orm.selectinload(m.Person.directed),
+        )
+        .filter_by(id=id)
+    )
+
+    person = (await sess.scalars(stmt)).first()
+
+    result = {
+        "id": person.id,
+        "image": person.image,
+        "full_name": person.full_name,
+        "bio": person.bio,
+        "acted_in": [
+            {
+                "id": m.id,
+                "image": m.image,
+                "title": m.title,
+                "year": m.year,
+                "avg_rating": float(m.avg_rating),
+            }
+            for m in sorted(person.acted_in, key=lambda x: (x.year, x.title))
+        ],
+        "directed": [
+            {
+                "id": m.id,
+                "image": m.image,
+                "title": m.title,
+                "year": m.year,
+                "avg_rating": float(m.avg_rating),
+            }
+            for m in sorted(person.directed, key=lambda x: (x.year, x.title))
+        ],
+    }
+
+    return json.dumps(result)
+
+
+async def update_movie(sess, id):
+    stmt = (
+        sa.update(m.Movie)
+        .filter_by(id=sa.bindparam("m_id"))
+        .values(title=m.Movie.title + sa.bindparam("suffix"))
+        .returning(
+            m.Movie.id,
+            m.Movie.title,
+        )
+    )
+
+    result = (
+        await sess.execute(stmt, dict(m_id=id, suffix=f"---{str(id)[:8]}"))
+    ).first()
+    # Without this commit, the changes end up being committed outside
+    # of where they are timed.
+    await sess.commit()
+
+    return json.dumps(
+        {
+            "id": result[0],
+            "title": result[1],
+        }
+    )
+
+
+async def insert_user(sess, val):
+    num = random.randrange(1_000_000)
+    user = m.User(name=f"{val}{num}", image=f"image_{val}{num}")
+    sess.add(user)
+    await sess.commit()
+
+    return json.dumps(
+        {
+            "id": user.id,
+            "name": user.name,
+            "image": user.image,
+        }
+    )
+
+
+async def insert_movie(sess, val):
+    num = random.randrange(1_000_000)
+    movie = m.Movie(
+        title=f'{val["prefix"]}{num}',
+        image=f'{val["prefix"]}image{num}.jpeg',
+        description=f'{val["prefix"]}description{num}',
+        year=num,
+    )
+    sess.add(movie)
+    await sess.commit()
+
+    people = (
+        await sess.scalars(
+            sa.select(m.Person)
+            .where(m.Person.id.in_(val["people"][0:4]))
+            .order_by(m.Person.id)
+        )
+    ).all()
+
+    directors = m.Directors(person_rel=people[0], movie_rel=movie)
+    sess.add(directors)
+    c0 = m.Cast(person_rel=people[1], movie_rel=movie)
+    c1 = m.Cast(person_rel=people[2], movie_rel=movie)
+    c2 = m.Cast(person_rel=people[3], movie_rel=movie)
+
+    sess.add_all([c0, c1, c2])
+
+    await sess.commit()
+
+    result = {
+        "id": movie.id,
+        "image": movie.image,
+        "title": movie.title,
+        "year": movie.year,
+        "description": movie.description,
+        "directors": [
+            {
+                "id": directors.person_rel.id,
+                "full_name": directors.person_rel.full_name,
+                "image": directors.person_rel.image,
+            }
+        ],
+        "cast": [
+            {
+                "id": c.person_rel.id,
+                "full_name": c.person_rel.full_name,
+                "image": c.person_rel.image,
+            }
+            for c in [c0, c1, c2]
+        ],
+    }
+    return json.dumps(result)
+
+
+async def insert_movie_plus(sess, val):
+    num = random.randrange(1_000_000)
+    director = m.Person(
+        first_name=f"{val}Alice",
+        middle_name="",
+        last_name=f"{val}Director",
+        image=f"{val}image{num}.jpeg",
+        bio="",
+    )
+    c0 = m.Person(
+        first_name=f"{val}Billie",
+        middle_name="",
+        last_name=f"{val}Actor",
+        image=f"{val}image{num+1}.jpeg",
+        bio="",
+    )
+    c1 = m.Person(
+        first_name=f"{val}Cameron",
+        middle_name="",
+        last_name=f"{val}Actor",
+        image=f"{val}image{num+2}.jpeg",
+        bio="",
+    )
+    movie = m.Movie(
+        title=f"{val}{num}",
+        image=f"{val}image{num}.jpeg",
+        description=f"{val}description{num}",
+        year=num,
+    )
+
+    sess.add_all([director, c0, c1, movie])
+    await sess.commit()
+
+    sess.add_all(
+        [
+            m.Directors(person_rel=director, movie_rel=movie),
+            m.Cast(person_rel=c0, movie_rel=movie),
+            m.Cast(person_rel=c1, movie_rel=movie),
+        ]
+    )
+
+    await sess.commit()
+
+    result = {
+        "id": movie.id,
+        "image": movie.image,
+        "title": movie.title,
+        "year": movie.year,
+        "description": movie.description,
+        "directors": [
+            {
+                "id": director.id,
+                "full_name": director.full_name,
+                "image": director.image,
+            }
+        ],
+        "cast": [
+            {
+                "id": c.id,
+                "full_name": c.full_name,
+                "image": c.image,
+            }
+            for c in [c0, c1]
+        ],
+    }
+    return json.dumps(result)
+
+
+async def setup(ctx, sess, queryname):
+    if queryname == "update_movie":
+        await sess.execute(
+            sa.update(m.Movie)
+            .values(title=sa.func.split_part(m.Movie.title, "---", 1))
+            .execution_options(synchronize_session=False)
+        )
+        await sess.commit()
+    elif queryname == "insert_user":
+        await sess.execute(
+            sa.delete(m.User)
+            .where(m.User.name.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        await sess.commit()
+    elif queryname in {"insert_movie", "insert_movie_plus"}:
+
+        await sess.execute(
+            sa.delete(m.Directors)
+            .where(m.Directors.movie_rel)
+            .where(m.Movie.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        await sess.execute(
+            sa.delete(m.Cast)
+            .where(m.Cast.movie_rel)
+            .where(m.Movie.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        await sess.execute(
+            sa.delete(m.Movie)
+            .where(m.Movie.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        await sess.execute(
+            sa.delete(m.Person)
+            .where(m.Person.image.like(f"{INSERT_PREFIX}%"))
+            .execution_options(synchronize_session=False)
+        )
+        await sess.commit()
+
+
+async def cleanup(ctx, sess, queryname):
+    if queryname in {
+        "update_movie",
+        "insert_user",
+        "insert_movie",
+        "insert_movie_plus",
+    }:
+        # The clean up is the same as setup for mutation benchmarks
+        await setup(ctx, sess, queryname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 alembic~=1.6.5
-sqlalchemy~=1.4.28
+sqlalchemy~=1.4.32
 Django~=3.0
 djangorestframework~=3.12.0
 edgedb~=0.23.0


### PR DESCRIPTION
Hi -

I've seen this repo coming up in tweets lately, took a look and thought I would modernize it with our latest APIs.  I appreciate that this benchmark suite took the time to make use of the "baked" API in order to give SQLAlchemy the best performance boost possible; the good news is 90% of the performance increase of "baked" is now standard for all SQLAlchemy queries.

As SQLAlchemy's place in the benching among Python systems is firmly in the spot "a little above Django and well below EdgeDB", while this PR does include some performance enhancements, I don't expect much in the way of speed improvements, although I was able to reduce the number of queries for a few of the test functions which should help.   What's important though is that as this benching suite is serving as one of relatively few examples of comparing and contrasting different object-relational applications, that the API use illustrated is also informative in itself, showing off just what it looks like to be using the tools in their most idiomatic way in the current day.   So from that perspective I am enthusiastic to show off our newer APIs, particularly the asyncio API as well as the use of "2.0 style" queries, and without the awkwardness of the "baked" system which was never intended to be a primary SQLAlchemy API.

In order to test this code I built some local harnesses that run just the SQLAlchemy parts without getting into the whole "make" with containers and all that, so I have not run the "bench.py" harness itself.   I think I got everything in there that's needed including the `ASYNC` attribute, but if there are problems running this please let me know and I will gladly try to find time to get the container part of this running (I'm on Fedora where we use podman, not docker).

thanks for providing this suite and I hope to get feedback!  