### PR TITLE
Add dotnet benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ venv*
 .python-version
 .dart_tool
 .packages
+_edgedb_js/querybuilder
+.venv
+/_dotnet/EdgeDB.Net.IMDBench/bin/*
+/_dotnet/EdgeDB.Net.IMDBench/obj/*
+/_dotnet/EdgeDB.Net.IMDBench/.vs/*
+

--- a/_dotnet/EdgeDB.Net.IMDBench/BenchmarkRunner.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/BenchmarkRunner.cs
@@ -1,0 +1,272 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks;
+using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using Humanizer;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench
+{
+    internal class BenchmarkRunner
+    {
+        public static Dictionary<string, Dictionary<string, BaseBenchmark>> AllBenchmarks { get; }
+
+        private readonly BenchmarkConfig _config;
+
+        static BenchmarkRunner()
+        {
+            // discover all benchmarks
+            var benchmarks = Assembly.GetExecutingAssembly().DefinedTypes.Where(x =>
+            {
+                return !x.IsAbstract && x.IsAssignableTo(typeof(BaseBenchmark));
+            });
+
+            AllBenchmarks = new();
+
+            // create instances and store them 
+            
+            foreach(var benchmark in benchmarks)
+            {
+                var inst = (BaseBenchmark)Activator.CreateInstance(benchmark)!;
+
+                AllBenchmarks.TryAdd(inst.Category, new());
+
+                AllBenchmarks[inst.Category] ??= new();
+
+                AllBenchmarks[inst.Category][inst.Name] = inst;
+            }
+        }
+
+        public BenchmarkRunner(BenchmarkConfig config)
+        {
+            _config = config;
+        }
+
+        public async Task SetupAsync()
+        {
+            var benchmarks = GetActiveBenchmarks();
+
+#if DEBUG
+            Console.WriteLine($"Setting up {benchmarks.Length} benchmarks...");
+#endif
+
+            for(int i = 0; i != benchmarks.Length; i++)
+            {
+                var benchmark = benchmarks[i];
+#if DEBUG
+                Console.WriteLine("Setting up benchmark {0}/{1}: {2}", i + 1, benchmarks.Length, benchmark);
+#endif
+                await benchmark.SetupAsync(_config);
+            }
+
+#if DEBUG
+            Console.WriteLine("Setup complete");
+#endif
+        }
+
+        public async Task WarmupAsync()
+        {
+            var benchmarks = GetActiveBenchmarks();
+
+#if DEBUG
+            Console.WriteLine($"Starting warmup with {benchmarks.Count()} benchmarks with a duration of {_config.Warmup}s");
+#endif
+            for (int i = 0; i < benchmarks.Length; i++)
+            {
+                var benchmark = benchmarks[i];
+                try
+                {
+#if DEBUG
+                    Console.WriteLine("Warming up benchmark {0}/{1}: {2}", i + 1, benchmarks.Length, benchmark);
+
+                    var results = await RunManyAsync(_config.Concurrency, () => BenchAsync(benchmark, _config.Warmup, _config.NumSamples));
+                    var stats = new BenchStats(results);
+
+                    Console.WriteLine("{0}: Avg: {1}μs Min: {2}μs Max: {3}μs", benchmark, stats.Average, stats.Min, stats.Max);
+#else
+                    await RunManyAsync(_config.Concurrency, () => BenchAsync(benchmark, _config.Warmup));
+#endif
+                }
+                catch (Exception x)
+                {
+                    Console.Error.WriteLine($"Exception in {benchmark.Category}.{benchmark.Name}: {x}");
+
+#if RELEASE
+                    Environment.Exit(1);
+#endif
+                }
+            }
+
+#if DEBUG
+            Console.WriteLine("Warmup complete");
+#endif
+        }
+
+        public async Task RunAsync()
+        {
+            var benchmarks = GetActiveBenchmarks();
+
+#if DEBUG
+            Console.WriteLine($"Starting benchmarks with {benchmarks.Count()} benchmarks with a duration of {_config.Duration}s");
+#endif
+            for (int i = 0; i < benchmarks.Length; i++)
+            {
+                var benchmark = benchmarks[i];
+                
+                BenchResult[] result;
+
+#if DEBUG
+                Console.WriteLine("Running benchmark {0}/{1}: {2}", i + 1, benchmarks.Length, benchmark);
+#endif
+                try
+                {
+                    result = await RunManyAsync(_config.Concurrency, () => BenchAsync(benchmark, _config.Duration, _config.NumSamples));
+                }
+                catch (Exception x)
+                {
+                    Console.Error.WriteLine($"Exception in {benchmark}: {x}");
+
+#if RELEASE
+                    Environment.Exit(1);
+#endif
+
+                    continue;
+                }
+
+                var stats = new BenchStats(result);
+#if RELEASE
+                // report results of this run
+                Console.WriteLine(JsonConvert.SerializeObject(stats, new JsonSerializerSettings 
+                {
+                    ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
+                }));
+#else
+
+                Console.WriteLine($"{benchmark.Category}.{benchmark.Name}: Avg: {stats.Average}μs. Min: {stats.Min}μs. Max: {stats.Max}μs.");
+#endif
+            }
+        }
+
+        private Task<TResult[]> RunManyAsync<TResult>(int count, Func<Task<TResult>> func)
+        {
+            List<Task<TResult>> tasks = new();
+
+            for(int i = 0; i != count; i++)
+            {
+                tasks.Add(func());
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        private async Task<BenchResult> BenchAsync(BaseBenchmark benchmark, long duration, int sampleCount = 0)
+        {
+            var startTime = DateTimeOffset.UtcNow;
+            var sw = new Stopwatch();
+
+            List<object?> samples = new();
+            List<TimeSpan> times = new();
+
+            do
+            {
+                await benchmark.IterationSetupAsync();
+
+                sw.Start();
+                var task = benchmark.BenchmarkAsync();
+                await task;
+                sw.Stop();
+
+                // record the sample
+                if (samples.Count < sampleCount && TryGetTaskResult(task, out var result))
+                {
+                    samples.Add(result);
+                }
+
+                // add the time
+                times.Add(sw.Elapsed);
+
+                // reset and go again
+                sw.Reset();
+            }
+            while ((DateTimeOffset.UtcNow - startTime).TotalSeconds <= duration);
+
+            return new BenchResult(benchmark.Category, benchmark.Name, samples, times, duration);
+        }
+
+        private BaseBenchmark[] GetActiveBenchmarks()
+        {
+            return AllBenchmarks
+                .Where(x => _config.Targets!.Contains(x.Key))
+                .SelectMany(x => x.Value.Where(y => _config.Queries!.Contains(y.Key)))
+                .Select(x => x.Value)
+                .ToArray();
+        }
+
+        private bool TryGetTaskResult(Task task, out object? result)
+        {
+            result = null;
+
+            var resultProp = task.GetType().GetProperty("Result", BindingFlags.Public | BindingFlags.Instance);
+
+            if (resultProp is null)
+                return false;
+
+            result = resultProp.GetValue(task);
+            return true;
+        }
+
+        private record BenchResult(string Category, string Name, List<object?> Samples, List<TimeSpan> Times, long Duration);
+
+        private class BenchStats
+        {
+            [JsonProperty("min_latency")]
+            public double Min { get; }
+
+            [JsonProperty("max_latency")]
+            public double Max { get; }
+
+            [JsonProperty("nqueries")]
+            public long NumQueries { get; }
+
+            [JsonProperty("samples")]
+            public object? Samples { get; }
+
+            [JsonProperty("latency_stats")]
+            public double[] Times { get; }
+
+            [JsonProperty("duration")]
+            public double Duration { get; }
+
+            [JsonProperty("avg_latency")]
+            public double Average { get; }
+
+            public BenchStats(BenchResult result)
+            {
+                Min = result.Times.Min(x => x.TotalMicroseconds);
+                Max = result.Times.Max(x => x.TotalMicroseconds);
+                NumQueries = result.Times.Count;
+                Samples = result.Samples;
+                Times = result.Times.Select(x => x.TotalMicroseconds).ToArray();
+                Duration = result.Times.Sum(x => x.TotalMilliseconds);
+
+                Average = result.Times.Average(x => x.TotalMicroseconds);
+            }
+
+            public BenchStats(BenchResult[] results)
+            {
+                Min = results.Min(result => result.Times.Min(x => x.TotalMicroseconds));
+                Max = results.Min(result => result.Times.Max(x => x.TotalMicroseconds));
+                NumQueries = results.Sum(result => result.Times.Count);
+                Samples = results.SelectMany(result => result.Samples).ToArray();
+                Times = results.SelectMany(result => result.Times.Select(x => x.TotalMicroseconds)).ToArray();
+                Duration = results.Average(result => result.Times.Sum(x => x.TotalMilliseconds));
+                Average = results.Average(result => result.Times.Average(x => x.TotalMicroseconds));
+            }
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/BaseBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/BaseBenchmark.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks
+{
+    public abstract class BaseBenchmark
+    {
+        public abstract string Name { get; }
+        public abstract string Category { get; }
+        
+        public virtual ValueTask IterationSetupAsync() { return ValueTask.CompletedTask; }
+
+        public virtual ValueTask SetupAsync(BenchmarkConfig config) { return ValueTask.CompletedTask; }
+
+        public abstract Task BenchmarkAsync();
+
+        public override string ToString()
+        {
+            return $"{Category}.{Name}";
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/BenchmarkConfig.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,48 @@
+﻿using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks
+{
+    public class BenchmarkConfig
+    {
+        [Option("concurrency")]
+        public int Concurrency { get; set; } = 1;
+
+        [Option("duration")]
+        public int Duration { get; set; } = 2;
+
+        [Option("timeout")]
+        public int Timeout { get; set; } = 5000;
+
+        [Option("warmup-time")]
+        public int Warmup { get; set; } = 6;
+        
+        [Option("output-format")]
+        public string? OutputFormat { get; set; }
+
+        [Option("host")]
+        public string Host { get; set; } = "localhost";
+        
+        public int Port
+            => int.Parse(RawPort);
+
+        [Option("nsamples")]
+        public int NumSamples { get; set; } = 0;
+
+        [Option("number-of-ids")]
+        public int NumIds { get; set; } = 10;
+
+        [Option("query")]
+        public IEnumerable<string>? Queries { get; set; }
+
+        [Option("target")]
+        public IEnumerable<string>? Targets { get; set; }
+
+        [Option("port")]
+        public string RawPort { get; set; } = "15432";
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/BaseEFCoreBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/BaseEFCoreBenchmark.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal abstract class BaseEFCoreBenchmark : BaseBenchmark
+    {
+        public override string Category => "efcore";
+
+        public int UserId { get; private set; }
+        public int PersonId { get; private set; }
+        public int MovieId { get; private set; }
+
+        public int[] MovieIds { get; private set; } = Array.Empty<int>();
+        public int[] UserIds { get; private set; } = Array.Empty<int>();
+        public int[] PeopleIds { get; private set; } = Array.Empty<int>();
+
+        private string? _host;
+        private int _port;
+
+        public override ValueTask IterationSetupAsync()
+        {
+            var rand = new Random();
+
+            UserId = UserIds[rand.Next(UserIds.Length)];
+            MovieId = MovieIds[rand.Next(MovieIds.Length)];
+            PersonId = PeopleIds[rand.Next(PeopleIds.Length)];
+
+            return base.IterationSetupAsync();
+        }
+
+        public override async ValueTask SetupAsync(BenchmarkConfig config)
+        {
+            _host = config.Host;
+            _port = config.Port;
+
+            using var context = CreateContext();
+
+            if(MovieIds.Length != config.NumIds)
+            {
+                MovieIds = await context.Movies.Select(x => x.Id).Take(config.NumIds).ToArrayAsync();
+                UserIds = await context.Users.Select(x => x.Id).Take(config.NumIds).ToArrayAsync();
+                PeopleIds = await context.Persons.Select(x => x.Id).Take(config.NumIds).ToArrayAsync();
+            }
+        }
+
+        public PostgresBenchContext CreateContext()
+            => new(_host!, _port);
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/GetMovieBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/GetMovieBenchmark.cs
@@ -1,0 +1,32 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal sealed class GetMovieBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "get_movie";
+
+        public override async Task<Movie> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            return await ctx.Movies
+                .Include(x => x.Directors
+                    .OrderBy(x => x.ListOrder)
+                    .OrderBy(x => x.Person.LastName))
+                .Include(x => x.Actors
+                    .OrderBy(x => x.ListOrder)
+                    .OrderBy(x => x.Person.LastName))
+                .Include(x => x.Reviews)
+                    .ThenInclude(x => x.Author)
+                .ApplyAverageRating()
+                .FirstAsync(x => x.Id == MovieId);
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/GetPersonBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/GetPersonBenchmark.cs
@@ -1,0 +1,43 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal class GetPersonBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "get_person";
+
+        public override async Task<Person> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            var person =  await ctx.Persons
+                .Include(x => x.Actors
+                    .OrderBy(y => y.Movie.Year)
+                    .OrderBy(y => y.Movie.Title)
+                ).ThenInclude(x => x.Movie)
+                .ThenInclude(x => x.Reviews)
+                .Include(x => x.Directors
+                    .OrderBy(x => x.Movie.Year)
+                    .OrderBy(x => x.Movie.Title)
+                ).ThenInclude(x => x.Movie)
+                .ThenInclude(x => x.Reviews)
+                .FirstAsync(x => x.Id == PersonId);
+
+            // include avg. rating
+            person.Actors
+                .Select(x => x.Movie)
+                .Concat(
+                    person.Directors
+                    .Select(x => x.Movie))
+                .ApplyAverageRating();
+
+            return person;
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/GetUserBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/GetUserBenchmark.cs
@@ -1,0 +1,31 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal sealed class GetUserBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "get_user";
+
+        public override async Task<User> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            var user = await ctx.Users
+                .Include(x => x.Reviews)
+                .ThenInclude(x => x.Movie)
+                .ThenInclude(x => x.Reviews)
+                .FirstAsync(x => x.Id == UserId);
+
+            // apply avg. rating
+            user.Reviews.Select(x => x.Movie).ApplyAverageRating();
+
+            return user;
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/InsertMovieBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/InsertMovieBenchmark.cs
@@ -1,0 +1,60 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal sealed class InsertMovieBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "insert_movie";
+        
+        private readonly Random _random = new();
+
+        private int _num;
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _random.Next(0, 50000);
+
+            return base.IterationSetupAsync();
+        }
+
+        public override async Task<Movie> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            var movie = new Movie()
+            {
+                Title = $"Movie {_num}",
+                Image = $"image_{_num}.jpeg",
+                Description = $"description {_num}",
+                Year = _num,
+            };
+
+            movie.Directors.Add(new Director
+            {
+                PersonId = PersonId
+            });
+
+            foreach(var id in PeopleIds[..4])
+            {
+                movie.Actors.Add(new Actor() { PersonId = id });
+            }
+
+            var entry = await ctx.Movies.AddAsync(movie);
+
+            await ctx.SaveChangesAsync();
+
+            return await ctx.Movies
+                .Include(x => x.Directors)
+                    .ThenInclude(x => x.Person)
+                .Include(x => x.Actors)
+                    .ThenInclude(x => x.Person)
+                .FirstAsync(x => x.Id == entry.Entity.Id);
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/InsertMoviePlusBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/InsertMoviePlusBenchmark.cs
@@ -1,0 +1,82 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal sealed class InsertMoviePlusBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "insert_movie_plus";
+
+        private readonly Random _random = new();
+
+        private int _num;
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _random.Next(0, 50000);
+
+            return base.IterationSetupAsync();
+        }
+        
+        public override async Task<Movie> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            var movie = new Movie()
+            {
+                Title = $"Movie {_num}",
+                Image = $"image_{_num}.jpeg",
+                Description = $"description {_num}",
+                Year = _num,
+            };
+
+            var people = new Person[]
+            {
+                new Person
+                {
+                    FirstName = "Alice",
+                    MiddleName = "",
+                    LastName = "Director",
+                    Image = $"image_{_num}.jpeg",
+                    Bio = ""
+                },
+                new Person
+                {
+                    FirstName = "Billie",
+                    MiddleName = "",
+                    LastName = "Actor",
+                    Image = $"image_{_num + 1}.jpeg",
+                    Bio = ""
+                },
+                new Person
+                {
+                    FirstName = "Cameron",
+                    MiddleName = "",
+                    LastName = "Actor",
+                    Image = $"image_{_num + 2}.jpeg",
+                    Bio = ""
+                }
+            };
+
+            movie.Directors.Add(new Director { Person = people[0] });
+
+            movie.Actors = people[1..].Select(x => new Actor { Person = x}).ToList();
+
+            var entry = await ctx.Movies.AddAsync(movie);
+
+            await ctx.SaveChangesAsync();
+
+            return await ctx.Movies
+                .Include(x => x.Directors)
+                    .ThenInclude(x => x.Person)
+                .Include(x => x.Actors)
+                    .ThenInclude(x => x.Person)
+                .FirstAsync(x => x.Id == entry.Entity.Id);
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/InsertUserBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/InsertUserBenchmark.cs
@@ -1,0 +1,42 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal sealed class InsertUserBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "insert_user";
+
+        private readonly Random _random = new();
+
+        private int _num;
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _random.Next(0, 50000);
+
+            return base.IterationSetupAsync();
+        }
+        
+        public override async Task<User> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            var user = new User
+            {
+                Name = $"User {_num}",
+                Image = $"image_{_num}"
+            };
+
+            var entry = await ctx.Users.AddAsync(user);
+
+            await ctx.SaveChangesAsync();
+
+            return entry.Entity;
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Actor.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Actor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+
+public partial class Actor
+{
+    public int Id { get; set; }
+
+    public int? ListOrder { get; set; }
+
+    public int PersonId { get; set; }
+
+    public int MovieId { get; set; }
+
+    public virtual Movie Movie { get; set; } = null!;
+
+    public virtual Person Person { get; set; } = null!;
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Director.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Director.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+
+public partial class Director
+{
+    public int Id { get; set; }
+
+    public int? ListOrder { get; set; }
+
+    public int PersonId { get; set; }
+
+    public int MovieId { get; set; }
+
+    public virtual Movie Movie { get; set; } = null!;
+
+    public virtual Person Person { get; set; } = null!;
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Movie.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Movie.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+
+public partial class Movie
+{
+    public int Id { get; set; }
+
+    public string Image { get; set; } = null!;
+
+    public string Title { get; set; } = null!;
+
+    public int Year { get; set; }
+
+    public string Description { get; set; } = null!;
+
+    public virtual ICollection<Actor> Actors { get; set; } = new List<Actor>();
+
+    public virtual ICollection<Director> Directors { get; set; } = new List<Director>();
+
+    public virtual ICollection<Review> Reviews { get; set; } = new List<Review>();
+
+    public double? AvgerageRating { get; set; }
+}
+
+public static class MovieHelpers
+{
+    public static IQueryable<Movie> ApplyAverageRating(this IQueryable<Movie> querable)
+    {
+        return querable
+            .Select(x => new Movie
+            {
+                Actors = x.Actors,
+                Description = x.Description,
+                Directors = x.Directors,
+                Id = x.Id,
+                Image = x.Image,
+                Reviews = x.Reviews,
+                Title = x.Title,
+                Year = x.Year,
+                AvgerageRating = x.Reviews.Any() ? x.Reviews.Average(y => y.Rating) : null
+            });
+    }
+
+    public static void ApplyAverageRating(this IEnumerable<Movie> movie)
+    {
+        foreach(var m in movie)
+        {
+            if(m.Reviews.Any())
+                m.AvgerageRating = m.Reviews.Average(x => x.Rating);
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Person.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Person.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+
+public partial class Person
+{
+    public int Id { get; set; }
+
+    public string FirstName { get; set; } = null!;
+
+    public string MiddleName { get; set; } = null!;
+
+    public string LastName { get; set; } = null!;
+
+    public string Image { get; set; } = null!;
+
+    public string Bio { get; set; } = null!;
+
+    public virtual ICollection<Actor> Actors { get; } = new List<Actor>();
+
+    public virtual ICollection<Director> Directors { get; } = new List<Director>();
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Review.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/Review.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+
+public partial class Review
+{
+    public int Id { get; set; }
+
+    public string Body { get; set; } = null!;
+
+    public int Rating { get; set; }
+
+    public DateTime CreationTime { get; set; }
+
+    public int AuthorId { get; set; }
+
+    public int MovieId { get; set; }
+
+    public virtual User Author { get; set; } = null!;
+
+    public virtual Movie Movie { get; set; } = null!;
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/User.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/Models/User.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+
+public partial class User
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public string Image { get; set; } = null!;
+
+    public virtual ICollection<Review> Reviews { get; } = new List<Review>();
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/PostgresBenchContext.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/PostgresBenchContext.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore;
+
+public partial class PostgresBenchContext : DbContext
+{
+    private static MemoryCache _zeroSizeMemoryCache = new MemoryCache(new MemoryCacheOptions() { SizeLimit = 0 });
+
+    private readonly int _port;
+    private readonly string _host;
+
+    public PostgresBenchContext(string host, int port)
+    {
+        _host = host;
+        _port = port;
+    }
+
+    public PostgresBenchContext(DbContextOptions<PostgresBenchContext> options)
+        : base(options)
+    {
+        _host = "localhost";
+        _port = 15432;
+    }
+
+    public virtual DbSet<Actor> Actors { get; set; }
+
+    public virtual DbSet<Director> Directors { get; set; }
+
+    public virtual DbSet<Movie> Movies { get; set; }
+
+    public virtual DbSet<Person> Persons { get; set; }
+
+    public virtual DbSet<Review> Reviews { get; set; }
+
+    public virtual DbSet<User> Users { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseMemoryCache(_zeroSizeMemoryCache) // disable cache
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)) // disable warning related to multiple singletons of the memory cache being added
+            .UseNpgsql($"Host={_host};Port={_port};Database=postgres_bench;User ID=postgres_bench;");
+    
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Actor>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("actors_pkey");
+
+            entity.ToTable("actors");
+
+            entity.HasIndex(e => e.MovieId, "actors_movie_index");
+
+            entity.HasIndex(e => e.PersonId, "actors_person_index");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.ListOrder).HasColumnName("list_order");
+            entity.Property(e => e.MovieId).HasColumnName("movie_id");
+            entity.Property(e => e.PersonId).HasColumnName("person_id");
+
+            entity.HasOne(d => d.Movie).WithMany(p => p.Actors)
+                .HasForeignKey(d => d.MovieId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("actors_movie_id_fkey");
+
+            entity.HasOne(d => d.Person).WithMany(p => p.Actors)
+                .HasForeignKey(d => d.PersonId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("actors_person_id_fkey");
+        });
+
+        modelBuilder.Entity<Director>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("directors_pkey");
+
+            entity.ToTable("directors");
+
+            entity.HasIndex(e => e.MovieId, "directors_movie_index");
+
+            entity.HasIndex(e => e.PersonId, "directors_person_index");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.ListOrder).HasColumnName("list_order");
+            entity.Property(e => e.MovieId).HasColumnName("movie_id");
+            entity.Property(e => e.PersonId).HasColumnName("person_id");
+
+            entity.HasOne(d => d.Movie).WithMany(p => p.Directors)
+                .HasForeignKey(d => d.MovieId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("directors_movie_id_fkey");
+
+            entity.HasOne(d => d.Person).WithMany(p => p.Directors)
+                .HasForeignKey(d => d.PersonId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("directors_person_id_fkey");
+        });
+
+        modelBuilder.Entity<Movie>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("movies_pkey");
+
+            entity.ToTable("movies");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Description).HasColumnName("description");
+            entity.Property(e => e.Image).HasColumnName("image");
+            entity.Property(e => e.Title).HasColumnName("title");
+            entity.Property(e => e.Year).HasColumnName("year");
+
+            entity.Ignore(e => e.AvgerageRating);
+        });
+
+        modelBuilder.Entity<Person>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("persons_pkey");
+
+            entity.ToTable("persons");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Bio).HasColumnName("bio");
+            entity.Property(e => e.FirstName).HasColumnName("first_name");
+            entity.Property(e => e.Image).HasColumnName("image");
+            entity.Property(e => e.LastName).HasColumnName("last_name");
+            entity.Property(e => e.MiddleName)
+                .HasDefaultValueSql("''::text")
+                .HasColumnName("middle_name");
+        });
+
+        modelBuilder.Entity<Review>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("reviews_pkey");
+
+            entity.ToTable("reviews");
+
+            entity.HasIndex(e => e.CreationTime, "creation_time_index");
+
+            entity.HasIndex(e => e.AuthorId, "review_author_index");
+
+            entity.HasIndex(e => e.MovieId, "review_movie_index");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.AuthorId).HasColumnName("author_id");
+            entity.Property(e => e.Body).HasColumnName("body");
+            entity.Property(e => e.CreationTime).HasColumnName("creation_time");
+            entity.Property(e => e.MovieId).HasColumnName("movie_id");
+            entity.Property(e => e.Rating).HasColumnName("rating");
+
+            entity.HasOne(d => d.Author).WithMany(p => p.Reviews)
+                .HasForeignKey(d => d.AuthorId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("reviews_author_id_fkey");
+
+            entity.HasOne(d => d.Movie).WithMany(p => p.Reviews)
+                .HasForeignKey(d => d.MovieId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("reviews_movie_id_fkey");
+        });
+
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("users_pkey");
+
+            entity.ToTable("users");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Image).HasColumnName("image");
+            entity.Property(e => e.Name).HasColumnName("name");
+        });
+
+        OnModelCreatingPartial(modelBuilder);
+    }
+
+    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/UpdateMovieBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EFCore/UpdateMovieBenchmark.cs
@@ -1,0 +1,39 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EFCore.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EFCore
+{
+    internal sealed class UpdateMovieBenchmark : BaseEFCoreBenchmark
+    {
+        public override string Name => "update_movie";
+
+        private readonly Random _random = new();
+
+        private int _num;
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _random.Next(0, 50000);
+
+            return base.IterationSetupAsync();
+        }
+        
+        public override async Task<Movie> BenchmarkAsync()
+        {
+            using var ctx = CreateContext();
+
+            var movie = await ctx.Movies.FirstAsync(x => x.Id == MovieId);
+
+            movie.Title = $"New Title {_num}";
+
+            await ctx.SaveChangesAsync();
+
+            return movie;
+        }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/BaseEdgeDBBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/BaseEdgeDBBenchmark.cs
@@ -1,0 +1,69 @@
+﻿using EdgeDB.State;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    public abstract class BaseEdgeDBBenchmark : BaseBenchmark
+    {
+        private static (Guid[], Guid[], Guid[])? _ids;
+
+        public override string Category => "edgedb_dotnet";
+        public EdgeDBClient Client { get; private set; } = null!;
+
+        public Guid UserId { get; private set; }
+        public Guid MovieId { get; private set; }
+        public Guid PersonId { get; private set; }
+
+
+        public Guid[] UserIds { get; private set; } = Array.Empty<Guid>();
+        public Guid[] MovieIds { get; private set; } = Array.Empty<Guid>();
+        public Guid[] PeopleIds { get; private set; } = Array.Empty<Guid>();
+
+        public override ValueTask IterationSetupAsync()
+        {
+            var rand = new Random();
+
+            UserId = UserIds[rand.Next(UserIds.Length)];
+            MovieId = MovieIds[rand.Next(MovieIds.Length)];
+            PersonId = PeopleIds[rand.Next(PeopleIds.Length)];
+
+            return base.IterationSetupAsync();
+        }
+
+        public override async ValueTask SetupAsync(BenchmarkConfig config)
+        {
+#if DEBUG
+            var connection = new EdgeDBConnection()
+            {
+                Port = config.Port,
+                TLSCertificateAuthority = "-----BEGIN CERTIFICATE-----\r\nMIIC0zCCAbugAwIBAgIRAOmkEvJqWEHSvrRnqLLPtsAwDQYJKoZIhvcNAQELBQAw\r\nGDEWMBQGA1UEAwwNRWRnZURCIFNlcnZlcjAeFw0yMjEwMzEyMjM3NTZaFw00MTEy\r\nMzEyMjM3NTZaMBgxFjAUBgNVBAMMDUVkZ2VEQiBTZXJ2ZXIwggEiMA0GCSqGSIb3\r\nDQEBAQUAA4IBDwAwggEKAoIBAQCtxZAVRpqpFWxycORcNCLorB6yZHhUsNBs08tC\r\nWY6oICt3h2QpIWtH4uB5XJHJBOTdRsk8sdiVIDeH8top/QecXaI67U2HNCKPovUh\r\nCOsKCkJJhrGDC4vRIXlBLqQAvr+RpvIjy9gQCZcFyKgBXKpvSzChJA7AFX+Ajcvz\r\nR6ypfxBqYMwv4G5inseha0I3LmGjW0EIJ7LIJP40E2/ZtmsSlx06rzfE91jYSQ85\r\n6sulwsYfVCe1PEK4yixnWwJyoh/X59GIXmNvW+2X3Bw1k1pv3ZfX3BvhRw9LdmQN\r\nWyfzkKzo+njLLgiDa/LWUVJ/Muns4UxMrRtEcBRCBqPpe6qHAgMBAAGjGDAWMBQG\r\nA1UdEQQNMAuCCTEyNy4wLjAuMTANBgkqhkiG9w0BAQsFAAOCAQEAhXNavQqBvTml\r\nvqR5P/0iDlitjbwwyv6J8O83mrYErY0PitLyZmsI1LygXuChMlOmmXk3cpjDO55A\r\n7yq2hMYspqyCVWAtgvsfEL1ftda66BFW6rUwKndNrYGCBoRRvwPIzk10Q/pFtwde\r\nsGkC989PYIzLjKyuttVjss71b7qcs21lFxGLZ9Sg8CCZl+b4nUQYXIEZhJTsUBms\r\nB9hOGrIPUYt2dmUfFA+DiR6xd2fkDDMr/7PxqLBMgC37RRVM6CGYtEsNov+Qbi4g\r\naJeYiGjdo/v7FpS8e1E+L8/356bIQWJZcvmveJggbS/78sj1OsRzmP3MhkOTZbky\r\nuiBuQUZ7kA==\r\n-----END CERTIFICATE-----\r\n"
+            };
+#else
+            var connection = EdgeDBConnection.ResolveEdgeDBTOML();
+#endif
+
+
+            Client = new EdgeDBClient(connection, new EdgeDBClientPoolConfig
+            {
+                SchemaNamingStrategy = INamingStrategy.SnakeCaseNamingStrategy
+            });
+
+            // get the ids
+            var ids = await GetIdsAsync(Client, config.NumIds);
+
+            UserIds = ids.Item1;
+            MovieIds = ids.Item2;
+            PeopleIds = ids.Item3;
+        }
+
+        private static async ValueTask<(Guid[], Guid[], Guid[])> GetIdsAsync(EdgeDBClient client, long numIds)
+            => _ids ??= await client.QueryRequiredSingleAsync<(Guid[], Guid[], Guid[])>(Queries.GET_IDS, new Dictionary<string, object?>()
+            {
+                { "num_ids", numIds }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/GetMovieBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/GetMovieBenchmark.cs
@@ -1,0 +1,20 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class GetMovieBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "get_movie";
+
+        public override Task<Movie> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<Movie>(Queries.SELECT_MOVIE, new Dictionary<string, object?>
+            {
+                { "id", MovieId }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/GetPersonBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/GetPersonBenchmark.cs
@@ -1,0 +1,20 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class GetPersonBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "get_person";
+        
+        public override Task<Person> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<Person>(Queries.SELECT_PERSON, new Dictionary<string, object?>
+            {
+                { "id", PersonId }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/GetUserBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/GetUserBenchmark.cs
@@ -1,0 +1,20 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class GetUserBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "get_user";
+
+        public override Task<User> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<User>(Queries.SELECT_USER, new Dictionary<string, object?>()
+            {
+                { "id", UserId }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/InsertMovieBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/InsertMovieBenchmark.cs
@@ -1,0 +1,41 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class InsertMovieBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "insert_movie";
+
+        private Random? _rand;
+        private int _num;
+
+        public override ValueTask SetupAsync(BenchmarkConfig config)
+        {
+            _rand = new();
+
+            return base.SetupAsync(config);
+        }
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _rand!.Next(0, 50000);
+            return base.IterationSetupAsync();
+        }
+
+        public override Task<Movie> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<Movie>(Queries.INSERT_MOVIE, new Dictionary<string, object?>()
+            {
+                { "title", "Movie " + _num },
+                { "image", "image_" + _num + ".jpeg"},
+                { "description", "description " + _num },
+                { "year", (long)_num },
+                { "d_id", PeopleIds[_num % PeopleIds.Length] },
+                { "cast", PeopleIds[..4] }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/InsertMoviePlusBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/InsertMoviePlusBenchmark.cs
@@ -1,0 +1,48 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class InsertMoviePlusBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "insert_movie_plus";
+
+        private Random? _rand;
+        private int _num;
+
+        public override ValueTask SetupAsync(BenchmarkConfig config)
+        {
+            _rand = new();
+
+            return base.SetupAsync(config);
+        }
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _rand!.Next(0, 50000);
+            return base.IterationSetupAsync();
+        }
+
+        public override Task<Movie> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<Movie>(Queries.INSERT_MOVIE_PLUS, new Dictionary<string, object?>
+            {
+                { "title", "Movie " + _num },
+                { "image", "image_" + _num + ".jpeg"},
+                { "description", "description " + _num },
+                { "year", (long)_num },
+                { "dfn", _num + "Alice" },
+                { "dln", _num + "Director" },
+                { "dimg", "image" + _num + ".jpeg" },
+                { "cfn0", _num + "Billie" },
+                { "cln0", _num + "Actor" },
+                { "cimg0", "image" + (_num + 1) + ".jpeg" },
+                { "cfn1", _num + "Cameron" },
+                { "cln1", _num + "Actor" },
+                { "cimg1", "image" + (_num + 2) + ".jpeg" },
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/InsertUserBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/InsertUserBenchmark.cs
@@ -1,0 +1,37 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class InsertUserBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "insert_user";
+        
+        private Random? _rand;
+        private int _num;
+
+        public override ValueTask SetupAsync(BenchmarkConfig config)
+        {
+            _rand = new();
+
+            return base.SetupAsync(config);
+        }
+
+        public override ValueTask IterationSetupAsync()
+        {
+            _num = _rand!.Next(0, 50000);
+            return base.IterationSetupAsync();
+        }
+
+        public override Task<User> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<User>(Queries.INSERT_USER, new Dictionary<string, object?>()
+            {
+                { "name", "name_" + _num },
+                { "image", "image_" + _num }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/HasImage.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/HasImage.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models
+{
+    internal class HasImage
+    {
+        public string? Image { get; set; }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/Movie.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/Movie.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models
+{
+    internal sealed class Movie : HasImage
+    {
+        public Person[]? Crew { get; set; }
+        public Person[]? Directors { get; set; }
+        public double AvgRating { get; set; }
+        public string? Description { get; set; }
+        public string? Title { get; set; }
+        public long Year { get; set; }
+
+        public Review[]? Reviews { get; set; }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/Person.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/Person.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models
+{
+    internal class Person : HasImage
+    {
+        public string? Bio { get; set; }
+
+        public string? FirstName { get; set; }
+        public string? FullName { get; set; }
+        public string? LastName { get; set; }
+        public string? MiddleName { get; set; }
+
+        [EdgeDBProperty("@list_order")]
+        public long ListOrder { get; set; }
+        
+        public Movie[]? ActedIn { get; set; }
+        public Movie[]? Directed { get; set; }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/Review.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/Review.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models
+{
+    internal sealed class Review
+    {
+        public User? Author { get; set; }
+        public Movie? Movie { get; set; }
+        public string? Body { get; set; }
+        public DateTime CreationTime { get; set; }
+        public long Rating { get; set; }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/User.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/Models/User.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models
+{
+    internal sealed class User : HasImage
+    {
+        public string? Name { get; set; }
+        
+        public Review[]? LatestReviews { get; set; }
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/UpdateMovieBenchmark.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Benchmarks/EdgeDB/UpdateMovieBenchmark.cs
@@ -1,0 +1,21 @@
+﻿using EdgeDB.Net.IMDBench.Benchmarks.EdgeDB.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench.Benchmarks.EdgeDB
+{
+    internal sealed class UpdateMovieBenchmark : BaseEdgeDBBenchmark
+    {
+        public override string Name => "update_movie";
+
+        public override Task<Movie> BenchmarkAsync()
+            => Client.QueryRequiredSingleAsync<Movie>(Queries.UPDATE_MOVIE, new Dictionary<string, object?>
+            {
+                { "id", MovieId },
+                { "suffix", MovieId.ToString() }
+            });
+    }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/EdgeDB.Net.IMDBench.csproj
+++ b/_dotnet/EdgeDB.Net.IMDBench/EdgeDB.Net.IMDBench.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="EdgeDB.Net.Driver" Version="1.0.3-build-90" />
+    <PackageReference Include="EFCore.NamingConventions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/_dotnet/EdgeDB.Net.IMDBench/EdgeDB.Net.IMDBench.sln
+++ b/_dotnet/EdgeDB.Net.IMDBench/EdgeDB.Net.IMDBench.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdgeDB.Net.IMDBench", "EdgeDB.Net.IMDBench.csproj", "{9BA64B3E-142F-4898-8CD3-D77CAACA1D9F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9BA64B3E-142F-4898-8CD3-D77CAACA1D9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BA64B3E-142F-4898-8CD3-D77CAACA1D9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BA64B3E-142F-4898-8CD3-D77CAACA1D9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BA64B3E-142F-4898-8CD3-D77CAACA1D9F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {42D607DF-2EE9-4D39-B2C4-B441CD5CB07F}
+	EndGlobalSection
+EndGlobal

--- a/_dotnet/EdgeDB.Net.IMDBench/Program.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Program.cs
@@ -1,0 +1,37 @@
+﻿using CommandLine;
+using EdgeDB;
+using EdgeDB.Net.IMDBench;
+using EdgeDB.Net.IMDBench.Benchmarks;
+using Newtonsoft.Json;
+
+var parser = new Parser(x =>
+{
+    x.HelpWriter = null;
+});
+
+await parser.ParseArguments<BenchmarkConfig>(args)
+    .WithNotParsed(x =>
+    {
+        foreach(var err in x)
+        {
+            Console.Error.WriteLine($"{err.Tag}: {JsonConvert.SerializeObject(err, Formatting.Indented)}");
+        }
+    })
+    .WithParsedAsync(async x =>
+    {
+        try
+        {
+            var benchmarkRunner = new BenchmarkRunner(x);
+
+            await benchmarkRunner.SetupAsync();
+
+            await benchmarkRunner.WarmupAsync();
+
+            await benchmarkRunner.RunAsync();
+        }
+        catch(Exception err)
+        {
+            Console.Error.WriteLine($"FATAL: {err}");
+            Environment.Exit(2);
+        }
+    });

--- a/_dotnet/EdgeDB.Net.IMDBench/Properties/launchSettings.json
+++ b/_dotnet/EdgeDB.Net.IMDBench/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "EdgeDB.Net.IMDBench": {
+      "commandName": "Project",
+      "commandLineArgs": "--concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query get_person --port 15656 --target edgedb_dotnet"
+    }
+  }
+}

--- a/_dotnet/EdgeDB.Net.IMDBench/Queries.cs
+++ b/_dotnet/EdgeDB.Net.IMDBench/Queries.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Net.IMDBench
+{
+    internal static class Queries
+    {
+        public const string SELECT_USER = @"
+SELECT User {
+    id,
+    name,
+    image,
+    latest_reviews := (
+        WITH UserReviews := User.<author[IS Review]
+        SELECT UserReviews {
+            id,
+            body,
+            rating,
+            movie: {
+                id,
+                image,
+                title,
+                avg_rating
+            }
+        }
+        ORDER BY .creation_time DESC
+        LIMIT 10
+    )
+}
+FILTER .id = <uuid>$id";
+
+        public const string SELECT_PERSON = @"
+SELECT Person {
+    id,
+    full_name,
+    image,
+    bio,
+    acted_in := (
+        WITH M := Person.<cast[IS Movie]
+        SELECT M {
+            id,
+            image,
+            title,
+            year,
+            avg_rating
+        }
+        ORDER BY .year ASC THEN .title ASC
+    ),
+    directed := (
+        WITH M := Person.<directors[IS Movie]
+        SELECT M {
+            id,
+            image,
+            title,
+            year,
+            avg_rating
+        }
+        ORDER BY .year ASC THEN .title ASC
+    ),
+}
+FILTER .id = <uuid>$id";
+
+        public const string SELECT_MOVIE = @"
+SELECT Movie {
+    id,
+    image,
+    title,
+    year,
+    description,
+    avg_rating,
+    directors: {
+        id,
+        full_name,
+        image,
+    }
+    ORDER BY Movie.directors@list_order EMPTY LAST
+        THEN Movie.directors.last_name,
+    cast: {
+        id,
+        full_name,
+        image,
+    }
+    ORDER BY Movie.cast@list_order EMPTY LAST
+        THEN Movie.cast.last_name,
+    reviews := (
+        SELECT Movie.<movie[IS Review] {
+            id,
+            body,
+            rating,
+            author: {
+                id,
+                name,
+                image,
+            }
+        }
+        ORDER BY .creation_time DESC
+    ),
+}
+FILTER .id = <uuid>$id";
+
+        public const string UPDATE_MOVIE = @"
+SELECT (
+    UPDATE Movie
+    FILTER .id = <uuid>$id
+    SET {
+        title := .title ++ '---' ++ <str>$suffix
+    }
+) {
+    id,
+    title
+}";
+
+        public const string INSERT_USER = @"
+SELECT (
+    INSERT User {
+        name := <str>$name,
+        image := <str>$image,
+    }
+) {
+    id,
+    name,
+    image,
+}";
+
+        public const string INSERT_MOVIE = @"
+SELECT (
+      INSERT Movie {
+          title := <str>$title,
+          image := <str>$image,
+          description := <str>$description,
+          year := <int64>$year,
+          directors := (
+              SELECT Person
+              FILTER .id = (<uuid>$d_id)
+          ),
+          cast := (
+              SELECT Person
+              FILTER .id IN array_unpack(<array<uuid>>$cast)
+          ),
+      }
+  ) {
+      id,
+      title,
+      image,
+      description,
+      year,
+      directors: {
+          id,
+          full_name,
+          image,
+      }
+      ORDER BY .last_name,
+      cast: {
+          id,
+          full_name,
+          image,
+      }
+      ORDER BY .last_name,
+  }";
+
+        public const string INSERT_MOVIE_PLUS = @"
+SELECT (
+    INSERT Movie {
+        title := <str>$title,
+        image := <str>$image,
+        description := <str>$description,
+        year := <int64>$year,
+        directors := (
+            INSERT Person {
+                first_name := <str>$dfn,
+                last_name := <str>$dln,
+                image := <str>$dimg,
+            }
+        ),
+        cast := {(
+            INSERT Person {
+                first_name := <str>$cfn0,
+                last_name := <str>$cln0,
+                image := <str>$cimg0,
+            }
+        ), (
+            INSERT Person {
+                first_name := <str>$cfn1,
+                last_name := <str>$cln1,
+                image := <str>$cimg1,
+            }
+        )},
+    }
+) {
+    id,
+    title,
+    image,
+    description,
+    year,
+    directors: {
+        id,
+        full_name,
+        image,
+    }
+    ORDER BY .last_name,
+    cast: {
+        id,
+        full_name,
+        image,
+    }
+    ORDER BY .last_name,
+}";
+
+        public const string GET_IDS = @"
+WITH
+    U := User {id, r := random()},
+    M := Movie {id, r := random()},
+    P := Person {id, r := random()}
+SELECT (
+    users := array_agg((SELECT U ORDER BY U.r LIMIT <int64>$num_ids).id),
+    movies := array_agg((SELECT M ORDER BY M.r LIMIT <int64>$num_ids).id),
+    people := array_agg((SELECT P ORDER BY P.r LIMIT <int64>$num_ids).id),
+)";
+    }
+}

--- a/_shared.py
+++ b/_shared.py
@@ -129,6 +129,12 @@ IMPLEMENTATIONS = {
 
     'postgres_dart':
         impl('dart', 'Postgres (Dart)', None),
+
+    'edgedb_dotnet':
+        impl("dotnet", "EdgeDB (.NET)", None),
+
+    'efcore':
+        impl("dotnet", "EFCore w/ Postgres (.NET)", None)
 }
 
 

--- a/bench.py
+++ b/bench.py
@@ -243,6 +243,10 @@ def run_benchmarks(args, argv):
             lang_args['dart'] = [
                 'python', 'bench_dart.py', '--json', '__tmp.json'
             ] + argv
+        elif bench.language == 'dotnet':
+            lang_args['dotnet'] = [
+                'python', 'bench_dotnet.py', '--json', '__tmp.json'
+            ]
         else:
             raise ValueError('unsupported host language: {}'.format(
                 bench.language))

--- a/bench_dotnet.py
+++ b/bench_dotnet.py
@@ -1,0 +1,150 @@
+import json
+import typing
+import _shared
+import subprocess
+import pathlib
+
+
+class Result(typing.NamedTuple):
+
+    benchmark: str
+    queryname: str
+    nqueries: int
+    duration: int
+    min_latency: int
+    avg_latency: int
+    max_latency: int
+    latency_stats: typing.List[int]
+    samples: typing.List[str]
+
+
+def run_query(ctx, benchmark, queryname):
+    dirn = pathlib.Path(__file__).resolve().parent
+    proj_dir = dirn / '_dotnet' / 'EdgeDB.Net.IMDBench'
+
+    opts = [
+        '--concurrency', ctx.concurrency,
+        '--duration', ctx.duration,
+        '--timeout', ctx.timeout,
+        '--warmup-time', ctx.warmup_time,
+        '--output-format', 'json',
+        '--host', ctx.db_host,
+        '--nsamples', 10,
+        '--number-of-ids', ctx.number_of_ids,
+        '--query', queryname,
+        '--target', benchmark,
+    ]
+
+    if benchmark.startswith('edgedb'):
+        opts.extend(('--port', ctx.edgedb_port))
+    else:
+        opts.extend(('--port', ctx.pg_port))
+
+    cmd = [
+        str(c) for c in (
+            ['dotnet', 'run', '-c', 'Release', '--']
+            + opts
+        )
+    ]
+
+    print("Running benchmark...")
+    print(' '.join(cmd))
+    try:
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, check=True,
+            cwd=proj_dir,
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.stderr)
+        raise
+
+    output = proc.stdout
+
+    data = json.loads(output)
+
+    return Result(
+        benchmark=benchmark,
+        queryname=queryname,
+        nqueries=data['nqueries'],
+        duration=data['duration'],
+        min_latency=data['min_latency'],
+        avg_latency=data['avg_latency'],
+        max_latency=data['max_latency'],
+        latency_stats=data['latency_stats'],
+        samples=data['samples'],
+    )
+
+
+def print_result(ctx, result: Result):
+    print(f'== {result.benchmark} : {result.queryname} ==')
+    print(f'queries:\t{result.nqueries}')
+    print(f'qps:\t\t{result.nqueries // ctx.duration} q/s')
+    print(f'min latency:\t{result.min_latency:.2f}μs')
+    print(f'avg latency:\t{result.avg_latency:.2f}μs')
+    print(f'max latency:\t{result.max_latency:.2f}μs')
+    print()
+
+
+def run_bench(ctx, benchmark):
+    results = []
+
+    for queryname in ctx.queries:
+        res = run_query(ctx, benchmark, queryname)
+        results.append(res)
+        print_result(ctx, res)
+
+    return results
+
+
+def main():
+    ctx, _ = _shared.parse_args(
+        prog_desc='EdgeDB Databases Benchmark (Dotnet drivers)',
+        out_to_json=True)
+
+    print('============ .NET ============')
+    print(f'queries:\t{", ".join(q for q in ctx.queries)}')
+    print(f'benchmarks:\t{", ".join(b for b in ctx.benchmarks)}')
+    print()
+    print("Running benchmarks...")
+
+    data = []
+    for benchmark in ctx.benchmarks:
+        bench_desc = _shared.IMPLEMENTATIONS[benchmark]
+        if bench_desc.language != 'dotnet':
+            continue
+
+        res = run_bench(ctx, benchmark)
+        data.append(res)
+
+    if ctx.json:
+        json_data = []
+        for results in data:
+            json_results = []
+            for r in results:
+                json_results.append({
+                    'queryname': r.queryname,
+                    'nqueries': r.nqueries,
+                    'min_latency': r.min_latency,
+                    'max_latency': r.max_latency,
+                    'latency_stats': [int(i) for i in r.latency_stats],
+                    'samples': r.samples,
+                })
+            json_data.append({
+                'benchmark': results[0].benchmark,
+                'duration': results[0].duration,
+                'queries': json_results,
+            })
+
+        data = json.dumps({
+            'language': 'dotnet',
+            'concurrency': ctx.concurrency,
+            'warmup_time': ctx.warmup_time,
+            'duration': ctx.duration,
+            'data': json_data,
+        })
+        with open(ctx.json, 'wt') as f:
+            f.write(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@prisma/client": "^3.2.1",
         "argparse": "^2.0.1",
-        "edgedb": "^0.15.2",
+        "edgedb": "^0.22.8",
         "lodash": "^4.17.21",
         "pg": "^8.7.1"
       },
@@ -68,9 +68,12 @@
       }
     },
     "node_modules/edgedb": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.15.2.tgz",
-      "integrity": "sha512-ssgL4AfIfwXUoDEsyhPq9osX2JCQw0vkui1fyHeuCkNZY/bMl5uSNYBCyaR9ualC6fiy+Lj0P028C+yOq/Hw4g==",
+      "version": "0.22.8",
+      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.22.8.tgz",
+      "integrity": "sha512-a5PZIiEcPs9N/NwWKUsPljhQp0PwEozPvQgRGVf6Y03IvRQQiFJY+NOTDrz6ZWgEI03bdthRF+LQQabwVUCIbA==",
+      "bin": {
+        "edgeql-js": "dist/reflection/cli.js"
+      },
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -309,9 +312,9 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "edgedb": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.15.2.tgz",
-      "integrity": "sha512-ssgL4AfIfwXUoDEsyhPq9osX2JCQw0vkui1fyHeuCkNZY/bMl5uSNYBCyaR9ualC6fiy+Lj0P028C+yOq/Hw4g=="
+      "version": "0.22.8",
+      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.22.8.tgz",
+      "integrity": "sha512-a5PZIiEcPs9N/NwWKUsPljhQp0PwEozPvQgRGVf6Y03IvRQQiFJY+NOTDrz6ZWgEI03bdthRF+LQQabwVUCIbA=="
     },
     "inherits": {
       "version": "2.0.4",


### PR DESCRIPTION
Adds both `edgedb_dotnet` and `efcore` ([most popular .NET ORM](https://learn.microsoft.com/en-us/ef/core/)) as a benchmark target.

**Requires .NET 7 SDK to run**